### PR TITLE
补充支付宝账单中交易关闭与信用服务处理

### DIFF
--- a/modules/imports/alipay_prove.py
+++ b/modules/imports/alipay_prove.py
@@ -127,8 +127,11 @@ class AlipayProve(Base):
                         entry, account, amount_string, 'CNY')
                     data.create_simple_posting(
                         entry, trade_account, None, None)
-                elif status == '交易关闭' and trade_account_original == '':
+                elif (status == '交易关闭' or status == '已关闭') and trade_account_original == '':
                     #ignore it?
+                    pass
+                elif status == '解冻成功' or status == '信用服务使用成功':
+                    # maybe should add to Liabilities?
                     pass
                 else:
                     print(row)
@@ -143,6 +146,8 @@ class AlipayProve(Base):
                         ), '-' + amount_string, 'CNY')
                     data.create_simple_posting(
                         entry, trade_account, None, None)
+                elif status == '交易关闭':
+                    pass
                 else:
                     print(row)
                     exit(0)


### PR DESCRIPTION
信用服务可能需要加到 Liabilities 里面，先跳过了，防止处理过程中 exit。

或许遇到未覆盖的情况，进行提示而不是直接退出比较好？通常这些是不需要处理的记录。